### PR TITLE
Allow env vars to override config file fields in config script

### DIFF
--- a/_config/env_schema.ts
+++ b/_config/env_schema.ts
@@ -1,6 +1,6 @@
 import { ExistingIdPolicy } from "../anonymisation.ts";
 import { DestinationUrl, Host, Port, ScramblerKey } from "./values_schema.ts";
-import { ValidatedDisambiguatedLifetimeExpression } from "./lifetimes.ts";
+import { EvaluatedDisambiguatedLifetimeExpression } from "./lifetimes.ts";
 import { z } from "../deps.ts";
 
 function isTrue(value: string): boolean {
@@ -26,7 +26,7 @@ export enum ConfigEnvars {
   config_file = "ANONYSTAT_CONFIG_FILE",
 }
 
-const _ConfigEnv = z.object({
+export const RawConfigEnv = z.object({
   ANONYSTAT_DATA_STREAM_MEASUREMENT_ID: EmptyStringAsUndefined.optional(),
   ANONYSTAT_DATA_STREAM_IN_MEASUREMENT_ID: EmptyStringAsUndefined.optional(),
   ANONYSTAT_DATA_STREAM_OUT_MEASUREMENT_ID: EmptyStringAsUndefined.optional(),
@@ -39,7 +39,7 @@ const _ConfigEnv = z.object({
     ScramblerKey,
   ).optional(),
   ANONYSTAT_USER_ID_LIFETIME: EmptyStringAsUndefined.pipe(
-    ValidatedDisambiguatedLifetimeExpression,
+    EvaluatedDisambiguatedLifetimeExpression,
   ).optional(),
   ANONYSTAT_USER_ID_EXISTING: EmptyStringAsUndefined.pipe(ExistingIdPolicy)
     .optional(),
@@ -48,12 +48,12 @@ const _ConfigEnv = z.object({
   ).optional(),
   ANONYSTAT_LISTEN_HOSTNAME: EmptyStringAsUndefined.pipe(Host).optional(),
 });
-export type ConfigValueEnvarName = keyof typeof _ConfigEnv.shape;
+export type ConfigValueEnvarName = keyof typeof RawConfigEnv.shape;
 export const configValueEnvarNames = Object.keys(
-  _ConfigEnv.shape,
+  RawConfigEnv.shape,
 ) as readonly ConfigValueEnvarName[];
 
-export const ConfigEnv = _ConfigEnv.superRefine((val, ctx) => {
+export const ConfigEnv = RawConfigEnv.superRefine((val, ctx) => {
   const ensurePresent = (name: keyof typeof val, other: keyof typeof val) => {
     if (val[other] !== undefined || val[name] !== undefined) return;
     ctx.addIssue({
@@ -82,4 +82,4 @@ export const ConfigEnv = _ConfigEnv.superRefine((val, ctx) => {
   );
 });
 export type ConfigEnv = z.infer<typeof ConfigEnv>;
-export type RawConfigEnv = z.input<typeof ConfigEnv>;
+export type RawConfigEnv = z.infer<typeof RawConfigEnv>;

--- a/_config/json_schema.ts
+++ b/_config/json_schema.ts
@@ -23,7 +23,7 @@ export const DataStreamInOut = z.object({
   in: DataStreamCredentials,
   out: DataStreamCredentials,
 });
-type DataStreamInOut = z.infer<typeof DataStreamInOut>;
+export type DataStreamInOut = z.infer<typeof DataStreamInOut>;
 
 export const DataStreamInOutShorthand = DataStreamCredentials.transform((
   ds,
@@ -46,7 +46,7 @@ export const ForwarderConfig = z.object({
   allow_debug: z.boolean().default(false),
   user_id: UserIdConfig.default({}),
 });
-type ForwarderConfig = z.infer<typeof ForwarderConfig>;
+export type ForwarderConfig = z.infer<typeof ForwarderConfig>;
 
 export const DEFAULT_PORT = 8000;
 export const DEFAULT_HOSTNAME = "127.0.0.1";

--- a/_config/lifetimes.ts
+++ b/_config/lifetimes.ts
@@ -56,6 +56,7 @@ export const LifetimeObject = z.object({
   unit: LaxTimeUnit,
   from: UtcDateOrDateTime.optional(),
 });
+export type LifetimeObject = z.infer<typeof LifetimeObject>;
 
 type ParsedLifetimeExpression = {
   expr: string;

--- a/_config/loading.ts
+++ b/_config/loading.ts
@@ -224,7 +224,9 @@ function loadConfigJsonValue(
   jsonValue: JsonValue,
   source: Source,
 ): Result<Config, LoadConfigError> {
-  const parseResult = Config.safeParse(jsonValue, { errorMap: customErrorMap });
+  const parseResult = Config.safeParse(jsonValue, {
+    errorMap: customErrorMap,
+  });
   if (!parseResult.success) {
     return {
       success: false,
@@ -273,8 +275,19 @@ function loadConfigEnv(rawEnv: EnvMap): Result<Config, LoadConfigError> {
     hostname: env.ANONYSTAT_LISTEN_HOSTNAME || undefined,
   };
 
+  const lifetime = env.ANONYSTAT_USER_ID_LIFETIME
+    ? {
+      count: env.ANONYSTAT_USER_ID_LIFETIME.count,
+      unit: env.ANONYSTAT_USER_ID_LIFETIME.unit,
+      from: env.ANONYSTAT_USER_ID_LIFETIME.from?.toISOString(),
+    }
+    : undefined;
+  if (lifetime && "from" in lifetime && lifetime.from === undefined) {
+    delete lifetime.from;
+  }
+
   const user_id: z.input<typeof UserIdConfig> = {
-    lifetime: env.ANONYSTAT_USER_ID_LIFETIME,
+    lifetime,
     existing: env.ANONYSTAT_USER_ID_EXISTING,
     scrambling_secret: env.ANONYSTAT_USER_ID_SCRAMBLING_SECRET,
   };

--- a/_config/loading_test.ts
+++ b/_config/loading_test.ts
@@ -1,5 +1,9 @@
 import { Config, ConfigInput } from "./json_schema.ts";
-import { ConfigEnvars, RawConfigEnv } from "./env_schema.ts";
+import {
+  ConfigEnvars,
+  ConfigValueEnvarName,
+  RawConfigEnv,
+} from "./env_schema.ts";
 import {
   ConfigLoadFailed,
   ConfigSource,
@@ -106,7 +110,7 @@ Deno.test("loadConfig()", async (t) => {
 
     await t.step("all envars", async () => {
       const configLoad = await loadConfig({
-        env: envMap<Required<RawConfigEnv>>({
+        env: envMap<Record<ConfigValueEnvarName, string>>({
           ANONYSTAT_ALLOW_DEBUG: "true",
           ANONYSTAT_DATA_STREAM_IN_API_SECRET: "secretIn",
           ANONYSTAT_DATA_STREAM_OUT_API_SECRET: "secretOut",

--- a/_config/mod.ts
+++ b/_config/mod.ts
@@ -1,6 +1,7 @@
+export type { DataStreamInOut, ForwarderConfig } from "./json_schema.ts";
 export { Config } from "./json_schema.ts";
 
-export type { LoadConfigError, LoadConfigOptions } from "./loading.ts";
+export type { EnvMap, LoadConfigError, LoadConfigOptions } from "./loading.ts";
 export {
   ConfigLoadFailed,
   ConfigSource,
@@ -8,7 +9,15 @@ export {
   loadConfigOrThrow,
 } from "./loading.ts";
 
-export { ConfigEnv, ConfigEnvars, EnvBool } from "./env_schema.ts";
+export {
+  ConfigEnv,
+  ConfigEnvars,
+  configValueEnvarNames,
+  EnvBool,
+  RawConfigEnv,
+} from "./env_schema.ts";
+
+export type { ConfigValueEnvarName } from "./env_schema.ts";
 
 export { getEnvars } from "./get_envars.ts";
 export type { GetEnvarsError } from "./get_envars.ts";

--- a/scripts/__snapshots__/config_test.ts.snap
+++ b/scripts/__snapshots__/config_test.ts.snap
@@ -3,20 +3,57 @@ export const snapshot = {};
 snapshot[`--help shows help 1`] = `
 "out|Validate and print anonystat config.
 out|
-out|Usage: deno run config.ts [-hc] [-f <format>] [<file>]
+out|Usage:
+out|  Usage: deno run config.ts [-hc] [-f <format>] [<file>] [-e <name>[=<value>|*]]...
 out|
 out|Configuration is read from environment variables unless <file> is provided, in
 out|which case environment variables are ignored.
 out|
+out|Values in the config loaded from <file> (or the environment) can be overridden
+out|by -e <name>[=<value>|*] options naming ANONYSTAT_ environment variables. A glob
+out|indicates all matching environment variables override.
+out|
+out|Examples:
+out|
+out|  # Load & validate config from env vars, print as NAME=VALUE
+out|  config.ts
+out|
+out|  # Load & validate config from config.json, print as NAME=VALUE
+out|  config.ts config.json
+out|
+out|  # Load from config.json, overriding the scrambling secret from the environment
+out|  config.ts config.json -e ANONYSTAT_USER_ID_SCRAMBLING_SECRET
+out|
+out|  # Load from config.json, overriding the scrambling secret to be 'foo'
+out|  config.ts config.json -e ANONYSTAT_USER_ID_SCRAMBLING_SECRET=foo
+out|
+out|  # Load from config.json, overriding values that are also set as env vars
+out|  config.ts config.json -e 'ANONYSTAT_*'
+out|
+out|  # Load from config.json, output as JSON without indentation
+out|  config.ts config.json --format json --compact
+out|
+out|
 out|Arguments:
-out|  <file>:  Path of a json[c] config file.
+out|  <file>:
+out|    Path of a json[c] config file.
 out|
 out|Options:
-out|  -f, --format: The representation to print after validating. <format> is:
-out|                'env', 'env-json', 'env-vars', 'json', 'markdown'.
-out|                                                                [Default: 'env']
-out|  -c, --compact: Don't indent JSON output
-out|  -h, --help:    Show this help
+out|  -f <format>, --format <format>:
+out|    The representation to print after validating. <format> is:
+out|    'env', 'env-json', 'env-vars', 'json', 'markdown'.          [Default: 'env']
+out|
+out|  -c, --compact:
+out|    Don't indent JSON output
+out|
+out|  -e <name>[=<value>|*], --override <name>[=<value>|*]:
+out|    Name an ANONYSTAT_ environment variable that overrides config values
+out|    loaded from the environment or <file>. <name> can end with a * to match
+out|    multiple, or =<value> to use the provided value instead of the value in the
+out|    environment.
+out|
+out|  -h, --help:
+out|    Show this help
 out|"
 `;
 


### PR DESCRIPTION
We now allow a config loaded from a JSON file to have individual fields selectively overridden by values from the environment (or command line arguments). This allows for secrets in environment variables to merge over a config file.

The use case I have for this is a CI run with an envar set from a CI secret, with the main config file committed in the repo.
